### PR TITLE
Add timer for breaks

### DIFF
--- a/src/Components/BreakTime.js
+++ b/src/Components/BreakTime.js
@@ -1,5 +1,32 @@
+import Timer from './Timer';
+import styled from 'styled-components';
+
+const EditableHeading = styled.h1`
+	resize: both;
+	outline: none;
+	overflow: auto;
+	font-weight: 300;
+	margin: 0;
+
+	&:focus {
+		border-bottom: 1px solid var(--accent-1);
+	}
+`;
+
 const BreakTime = () => {
-	return <div>Break-time</div>;
+	return (
+		<>
+			<EditableHeading
+				contentEditable="true"
+				suppressContentEditableWarning="true"
+				spellCheck="false"
+				data-gramm_editor="false"
+			>
+				Break
+			</EditableHeading>
+			<Timer format="breakTimeFormat" />
+		</>
+	);
 };
 
 export default BreakTime;

--- a/src/Components/Questions.js
+++ b/src/Components/Questions.js
@@ -34,7 +34,6 @@ const Input = styled.input`
 
 const Questions = () => {
 	const randomImage = images[Math.floor(Math.random() * images.length)].default;
-	console.log(randomImage);
 	return (
 		<PageContainer>
 			<ImageContainer imgSrc={randomImage} />

--- a/src/Components/Timer.js
+++ b/src/Components/Timer.js
@@ -1,0 +1,264 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import styled from 'styled-components';
+import { Button, OutlineButton } from './shared/buttons';
+
+const TimerDisplay = styled.h1`
+	font-size: clamp(6rem, 15vw, 15rem);
+	margin: 1rem 0;
+	user-select: none;
+`;
+
+const TimerControls = styled.form`
+	padding: 1rem 0;
+	max-width: 30rem;
+	opacity: 0.25;
+	transition: opacity 0.25s ease-in;
+
+	&:hover {
+		opacity: 1;
+	}
+
+	&:focus-within {
+		opacity: 1;
+	}
+`;
+
+const RangeSlider = styled.input.attrs((props) => ({
+	type: 'range',
+}))`
+	margin: 0.5rem 0;
+	width: 100%;
+	-webkit-appearance: none;
+
+	&:focus {
+		outline: none;
+	}
+
+	&::-webkit-slider-runnable-track {
+		background-color: var(--accent-1);
+		border: none;
+		border-radius: 1rem;
+		cursor: pointer;
+		height: 1.5rem;
+		width: 100%;
+	}
+
+	&::-moz-range-track {
+		background: var(--accent-1);
+		border: none;
+		border-radius: 1rem;
+		cursor: pointer;
+		height: 1.5rem;
+		width: 100%;
+	}
+
+	&::-webkit-slider-thumb {
+		background: var(--dk-1);
+		border: none;
+		border-radius: 2rem 2rem 0 2rem;
+		cursor: pointer;
+		height: 2rem;
+		transform: translateY(-0.25rem) rotate(45deg);
+		width: 2rem;
+		-webkit-appearance: none;
+	}
+
+	&::-moz-range-thumb {
+		background: var(--dk-1);
+		border: none;
+		border-radius: 2rem 2rem 0 2rem;
+		cursor: pointer;
+		height: 2rem;
+		transform: translateY(-0.25rem) rotate(45deg);
+		width: 2rem;
+		-webkit-appearance: none;
+	}
+`;
+
+const SliderTicks = styled.datalist`
+	display: flex;
+	justify-content: space-between;
+
+	& > option {
+		border-radius: 50%;
+		color: var(--dk-1);
+		cursor: pointer;
+		display: grid;
+		font-weight: bold;
+		height: 2rem;
+		place-content: center;
+		text-align: center;
+		transition: background 0.25s, border 0.25s;
+		user-select: none;
+		width: 2rem;
+	}
+
+	& > option:hover {
+		background: var(--accent-1);
+		background-blend-mode: lighten;
+		background-image: linear-gradient(rgba(255, 255, 255, 0.5) 0 0);
+		border: 1px solid var(--dk-1);
+	}
+
+	& > option:focus {
+		background: var(--accent-1);
+		background-blend-mode: lighten;
+		background-image: linear-gradient(rgba(255, 255, 255, 0.5) 0 0);
+		border: 1px solid var(--dk-1);
+		outline: none;
+	}
+`;
+
+const RangeSliderLabel = styled.label`
+	display: block;
+	font-weight: bold;
+	margin-bottom: 1rem;
+
+	&:span {
+		color: var(--dk-1);
+	}
+`;
+
+const ProgressBar = styled.div`
+	background-color: var(--lt);
+	bottom: 0;
+	height: 2rem;
+	left: 0;
+	position: absolute;
+	right: 0;
+
+	&::before {
+		content: '';
+		background-image: linear-gradient(to right, var(--accent-3), var(--dk-3));
+		height: 100%;
+		position: absolute;
+		transition: width 1s linear;
+		width: ${(props) => props.percentage + '%'};
+	}
+`;
+
+const Timer = ({ format }) => {
+	const [[hrs, mins, secs], setTime] = useState([0, 0, 0]);
+	const [isPaused, setIsPaused] = useState(false);
+	const [[hours, minutes, seconds], setTimer] = useState([hrs, mins, secs]);
+	const intervalId = useRef(null);
+
+	const pause = () => {
+		clearInterval(intervalId.current);
+		setIsPaused(true);
+	};
+
+	const reset = () => {
+		setTimer([hrs, mins, secs]);
+		pause();
+	};
+
+	const tick = useCallback(
+		(resume) => {
+			if (isPaused && !resume) return;
+			setIsPaused(false);
+			if (hours === 0 && minutes === 0 && seconds === 0) {
+				pause();
+			} else if (minutes === 0 && seconds === 0) {
+				setTimer([hours - 1, 59, 59]);
+			} else if (seconds === 0) {
+				setTimer([hours, minutes - 1, 59]);
+			} else {
+				setTimer([hours, minutes, seconds - 1]);
+			}
+		},
+		[hours, minutes, seconds, isPaused]
+	);
+
+	useEffect(() => {
+		intervalId.current = setInterval(() => tick(), 1000);
+		return () => clearInterval(intervalId.current);
+	}, [hours, minutes, seconds, tick]);
+
+	const displayTime = () => {
+		const lunchTimeFormat = `${hours.toString().padStart(2, '0')}h ${minutes
+			.toString()
+			.padStart(2, '0')}m ${seconds.toString().padStart(2, '0')}s`;
+		const breakTimeFormat = `${minutes ? minutes + 'm' : ''} ${
+			minutes ? seconds.toString().padStart(2, '0') : seconds
+		}s`;
+		return format === 'breakTimeFormat' ? breakTimeFormat : lunchTimeFormat;
+	};
+
+	const setAll = (minutes) => {
+		setTime([0, minutes, 0]);
+		setTimer([0, minutes, 0]);
+	};
+
+	const timerExec = (key) => {
+		if (key === 'KeyS') {
+			tick(true);
+		} else if (key === 'KeyR') {
+			reset();
+		} else if (key === 'KeyP') {
+			pause();
+		}
+	};
+
+	return (
+		<>
+			<TimerDisplay>{displayTime()}</TimerDisplay>
+			{!isPaused && (
+				<Button variant="error" onClick={pause}>
+					Stop
+				</Button>
+			)}
+			{isPaused && (
+				<Button variant="accent-1" onClick={() => tick(true)}>
+					Start
+				</Button>
+			)}
+			<OutlineButton variant="error" onClick={reset}>
+				Reset
+			</OutlineButton>
+			<TimerControls onKeyDown={(event) => timerExec(event.code)}>
+				<RangeSliderLabel htmlFor="time">
+					Break Time: <span>{mins} minutes</span>
+				</RangeSliderLabel>
+				<RangeSlider
+					id="time"
+					name="time"
+					step="1"
+					list="tickmarks"
+					min={0}
+					max={20}
+					value={mins}
+					onChange={(event) => setAll(parseInt(event.target.value, 10))}
+				/>
+				<SliderTicks id="tickmarks">
+					{[0, 5, 10, 15, 20].map((val) => (
+						<option
+							onKeyDown={(event) => {
+								if (event.key === 'Enter') {
+									setAll(parseInt(event.target.value, 10));
+								}
+							}}
+							aria-label={`Set time for ${val} minutes`}
+							tabIndex="0"
+							key={val}
+							value={val.toString()}
+							label={val.toString()}
+							onClick={() => setAll(val)}
+						>
+							{val}
+						</option>
+					))}
+				</SliderTicks>
+			</TimerControls>
+			<ProgressBar
+				percentage={
+					100 /
+					((hrs * 60 * 60 + mins * 60 + secs) /
+						(hours * 60 * 60 + minutes * 60 + seconds))
+				}
+			/>
+		</>
+	);
+};
+
+export default Timer;

--- a/src/Components/shared/buttons.js
+++ b/src/Components/shared/buttons.js
@@ -1,0 +1,111 @@
+import styled from 'styled-components';
+
+const variants = {
+	'accent-1': {
+		alpha: 'var(--accent-1a)',
+		mid: 'var(--accent-1)',
+		light: 'var(--lt)',
+		dark: 'var(--dk-1)',
+	},
+	'accent-2': {
+		alpha: 'var(--accent-2a)',
+		mid: 'var(--accent-2)',
+		light: 'var(--lt)',
+		dark: 'var(--dk-2)',
+	},
+	'accent-3': {
+		alpha: 'var(--accent-3a)',
+		mid: 'var(--accent-3)',
+		light: 'var(--lt)',
+		dark: 'var(--dk-3)',
+	},
+	'accent-4': {
+		alpha: 'var(--accent-4a)',
+		mid: 'var(--accent-4)',
+		light: 'var(--lt)',
+		dark: 'var(--dk-4)',
+	},
+	error: {
+		alpha: 'var(--error-a)',
+		mid: 'var(--error)',
+		light: 'var(--lt)',
+		dark: 'var(--error-dk)',
+	},
+	success: {
+		alpha: 'var(--accent-1a)',
+		mid: 'var(--accent-1a)',
+		light: 'var(--lt)',
+		dark: 'var(--dk-1)',
+	},
+};
+
+const ButtonBase = styled.button`
+	color: inherit;
+	background-color: transparent;
+	border-radius: 0.25rem;
+	border: 1px solid transparent;
+	display: inline-block;
+	font-family: inherit;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.5;
+	margin: 0;
+	overflow: visible;
+	padding: 0.375rem 0.75rem;
+	text-align: center;
+	text-transform: none;
+	transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+		border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+	user-select: none;
+	vertical-align: middle;
+	white-space: nowrap;
+
+	&:not(:disabled) {
+		cursor: pointer;
+	}
+
+	&:focus {
+		outline: 0;
+		text-decoration: none;
+	}
+
+	& + button {
+		margin-left: 0.5rem;
+	}
+`;
+
+export const Button = styled(ButtonBase)`
+	background-color: ${({ variant }) =>
+		variant ? variants[variant].mid : 'transparent'};
+	border-color: ${({ variant }) =>
+		variant ? variants[variant].mid : 'transparent'};
+	color: ${({ variant }) => (variant ? variants[variant].light : 'inherit')};
+
+	&:hover {
+		background-color: ${({ variant }) =>
+			variant ? variants[variant].dark : 'transparent'};
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 0.2rem
+			${({ variant }) => (variant ? variants[variant].alpha : 'transparent')};
+	}
+`;
+
+export const OutlineButton = styled(ButtonBase)`
+	background-color: var(--lt);
+	border-color: ${({ variant }) =>
+		variant ? variants[variant].dark : 'transparent'};
+	color: ${({ variant }) => (variant ? variants[variant].dark : 'inherit')};
+
+	&:hover {
+		color: var(--lt);
+		background-color: ${({ variant }) =>
+			variant ? variants[variant].dark : 'transparent'};
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 0.2rem
+			${({ variant }) => (variant ? variants[variant].alpha : 'transparent')};
+	}
+`;

--- a/src/Components/shared/headerComponents.js
+++ b/src/Components/shared/headerComponents.js
@@ -31,17 +31,22 @@ export const NavListItem = styled.li`
 	font-weight: bold;
 	padding: 1rem;
 	text-align: center;
+	transition: background 0.15s;
 	user-select: none;
 
+	&.active,
 	&:hover,
-	&.active {
+	&:focus,
+	&:focus-within {
 		background-blend-mode: darken;
+		outline: none;
 	}
 
 	> a {
 		color: inherit;
 		display: inline-block;
 		margin: -1rem;
+		outline: none;
 		padding: 1rem;
 		text-align: inherit;
 		width: calc(100% + 2rem);
@@ -52,6 +57,7 @@ export const TitleBar = styled.div`
 	align-items: center;
 	display: grid;
 	grid-template-columns: 1fr 150px;
+	gap: 1rem;
 	margin-bottom: 1rem;
 `;
 

--- a/src/Components/shared/mainComponents.js
+++ b/src/Components/shared/mainComponents.js
@@ -2,4 +2,5 @@ import styled from 'styled-components';
 
 export const Main = styled.main`
 	padding: 1rem;
+	position: relative;
 `;

--- a/src/index.css
+++ b/src/index.css
@@ -4,11 +4,20 @@
 	box-sizing: border-box;
 }
 
+:focus:not(:focus-visible) {
+	outline: none;
+}
+
 :root {
-	--accent-1: #36c2b3;
-	--accent-2: #1cc9f7;
+	--accent-1: #2fac9f;
+	--accent-2: #19bce9;
 	--accent-3: #4d27aa;
 	--accent-4: #e617e6;
+
+	--accent-1a: #2fac9f80;
+	--accent-2a: #19bce980;
+	--accent-3a: #4d27aa80;
+	--accent-4a: #e617e680;
 
 	--dk-1: #196159;
 	--dk-2: #476180;
@@ -18,6 +27,8 @@
 	--lt: #f5f5f5;
 	--dk: #000000;
 	--error: #c00e16;
+	--error-a: #c00e1680;
+	--error-dk: #6a090e;
 
 	--text-dk: var(--dk);
 	--text-lt: var(--lt);
@@ -51,4 +62,8 @@ img {
 	display: grid;
 	grid-template-rows: min-content auto min-content;
 	min-height: 100vh;
+}
+
+datalist option:hover {
+	background: blue;
 }


### PR DESCRIPTION
Added a timer for breaks.  Uses contenteditable for the break page
heading.  Timer features start with "S" key, pause with "P" key, reset
time with "R" key.  All interactive features are keyboard accessible.
Range slider uses datalist for ticks, which is not supported in Safari.
Not tested in MS Edge.  Base components need to be decoupled.